### PR TITLE
Add node name to the info output

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ module.exports = function(RED) {
                     node.send({
                         topic: 'info',
                         payload: {
+                            name: function() {
+                                return node.name || 'eztimer';
+                            }(),
                             on: function() {
                                 if (isSuspended()) return 'suspended';
                                 if (events.on.type == '9') return 'manual';


### PR DESCRIPTION
Hi Ben, 

I wanted to add the node's name to the output of the 'info' command as I use info to update a label showing when the timer is next going to run.  This is needed since I have a flow that allows users to change the timer on-time using a drop-down.  Since I have 4 timers and 4 labels in the dashboard, I needed to route the message to the correct label based on the timer name.

If the node has no name provided by the user, I thought about using the 'autoname' function, but I think it would mean copying that function from the index.html to the js and not sure if you wanted to do that as now there are two places to maintain?  I don't know enough about NodeRED as to whether a function can be shared between the html and the server-side js.

PS, I could have asked you to add this as it is a simple change, but also wanted to try my hand at using Github!

Thanks,
Stu