### PR TITLE
Don't assume home assistant global is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,24 +60,26 @@ module.exports = function(RED) {
             let ha = node.context().global.get('homeassistant');
             let zones = [];
 
-            let servers = Object.keys(ha);
-            let multipleServers = servers.length > 1;
-            for (server of servers) {
-              for (element in ha[server].states) {
-                let zone = ha[server].states[element];
-                if (element.substring(0, 4) == "zone") {
-                  let z = {
-                    entity_id: zone.entity_id,
-                    name: multipleServers
-                      ? `${server}: ${zone.attributes.friendly_name}`
-                      : zone.attributes.friendly_name,
-                    latitude: zone.attributes.latitude,
-                    longitude: zone.attributes.longitude,
-                  };
-                  if (z.entity_id.substring(0, 9) == "zone.home") zones.unshift(z);
-                  else zones.push(z);
+            if (ha) {
+                let servers = Object.keys(ha);
+                let multipleServers = servers.length > 1;
+                for (server of servers) {
+                    for (element in ha[server].states) {
+                        let zone = ha[server].states[element];
+                        if (element.substring(0, 4) == "zone") {
+                            let z = {
+                                entity_id: zone.entity_id,
+                                name: multipleServers
+                                    ? `${server}: ${zone.attributes.friendly_name}`
+                                    : zone.attributes.friendly_name,
+                                latitude: zone.attributes.latitude,
+                                longitude: zone.attributes.longitude,
+                            };
+                            if (z.entity_id.substring(0, 9) == "zone.home") zones.unshift(z);
+                            else zones.push(z);
+                        }
+                    }
                 }
-              }
             }
             res.json(zones);
         });


### PR DESCRIPTION
I'm running NodeRed stand-alone (so no HA integration) with this module and I noticed the following issue appearing in my logs:

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /data/node_modules/node-red-contrib-eztimer/index.js:63:34
    at Layer.handle [as handle_request] (/usr/src/node-red/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/src/node-red/node_modules/express/lib/router/route.js:137:13)
    at /usr/src/node-red/node_modules/@node-red/editor-api/lib/auth/index.js:75:13
    at Layer.handle [as handle_request] (/usr/src/node-red/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/src/node-red/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/usr/src/node-red/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/usr/src/node-red/node_modules/express/lib/router/layer.js:95:5)
    at /usr/src/node-red/node_modules/express/lib/router/index.js:281:22
```

If I'm correct, this PR should fix this issue by checking if the global homeassistant is populated before the object can be listed. The net result is that this HTTP endpoint will return an empty zone array.